### PR TITLE
update arguments for jq

### DIFF
--- a/doc_source/emr-jupyterhub-pam-users.md
+++ b/doc_source/emr-jupyterhub-pam-users.md
@@ -53,7 +53,7 @@ do
    sudo docker exec jupyterhub useradd -m -s /bin/bash -N $i
    sudo docker exec jupyterhub bash -c "echo $i:$i | chpasswd"
    curl -XPOST --silent -k https://$(hostname):9443/hub/api/users/$i \
- -H "Authorization: token $TOKEN" | jq
+ -H "Authorization: token $TOKEN" | jq '.'
 done
 ```
 


### PR DESCRIPTION

*Issue #:*
The command  `$ curl -XPOST --silent -k https://$(hostname):9443/hub/api/users/$i \
 -H "Authorization: token $TOKEN" | jq` in the script throws error when run as step. The users will be created successfully and will be able to login to jupyterhub but the step fails with exit code '2' due to jq command, because it expects an argument. 

*Description of changes:*
The argument '.' produces the formatted output without modifying it. Passing '.' will resolve the issue and step will complete successfully with exit code '0'.